### PR TITLE
Remove worker from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-web: bundle exec rails server -p $PORT -e $RAILS_ENV
-worker: npm start
+web: bundle exec rails server -p ${PORT:-5000} -e $RAILS_ENV


### PR DESCRIPTION
Adding a worker dyno may have been a blind alley. After moving the Node.js buildpack to BEFORE the Ruby buildpack (good idea to check old notes!), I'm reverting the Procfile to (more or less) what it was.