### PR TITLE
Create Temporary Columns in UserDailies and UserMicros Tables

### DIFF
--- a/db/migrate/20240221223856_add_temp_timer_to_user_dailies.rb
+++ b/db/migrate/20240221223856_add_temp_timer_to_user_dailies.rb
@@ -1,0 +1,5 @@
+class AddTempTimerToUserDailies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_dailies, :temp_timer_seconds, :integer, default: 0
+  end
+end

--- a/db/migrate/20240221231948_add_temp_timer_to_user_micros.rb
+++ b/db/migrate/20240221231948_add_temp_timer_to_user_micros.rb
@@ -1,0 +1,5 @@
+class AddTempTimerToUserMicros < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_micros, :temp_timer_seconds, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_19_174742) do
+ActiveRecord::Schema.define(version: 2024_02_21_231948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2023_06_19_174742) do
     t.bigint "daily_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "temp_timer_seconds", default: 0
     t.index ["daily_id"], name: "index_user_dailies_on_daily_id"
     t.index ["user_id"], name: "index_user_dailies_on_user_id"
     t.index ["wordcross_date"], name: "index_user_dailies_on_wordcross_date"
@@ -64,6 +65,7 @@ ActiveRecord::Schema.define(version: 2023_06_19_174742) do
     t.bigint "micro_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "temp_timer_seconds", default: 0
     t.index ["micro_id"], name: "index_user_micros_on_micro_id"
     t.index ["user_id"], name: "index_user_micros_on_user_id"
     t.index ["wordcross_date"], name: "index_user_micros_on_wordcross_date"

--- a/lib/tasks/update_timer_format.rake
+++ b/lib/tasks/update_timer_format.rake
@@ -1,0 +1,51 @@
+# Usage: bundle exec rake user_daily:convert_timer_to_seconds
+
+# These rake tasks were used as part of changing the data type by which the wordcross timers were represented. Originally, the timer data was stored as an array of strings, `["00", "00", "00"]`. The strings were converted to 3 integers in Redux state, then changed back to strings when the value was updated in the database... not good, obviously. Unnecessary complexity and potential for error.
+
+# Migrations 20240221223856_add_temp_timer_to_user_dailies.rb and 20240221231948_add_temp_timer_to_user_micros.rb added a temporary column to the UserDailies and UserMicros tables for storing the timer as an integer representing elapsed seconds. These tasks convert the old string data to the new integer format and store them in the temporary columns. They only update records that have not yet been updated, and rollback the transaction if an error occurs, so they are indempotent and atomic.
+
+# As of 2/21/2024, these tasks were run once in development. I will run those migrations on production, and then run these rake tasks on production.
+
+# A migration to remove the old timer columns and rename the temporary versions as :timer will be created and it will be run on production when the entire statistics feature is deployed. That deploy will include an updated seed file that will populate the timer columns with integers, not arrays of strings.
+
+# Following the deployment, this task should be irrelevant and may be deleted or kept for historical purposes.
+
+namespace :user_daily do
+  desc "Convert timer from array of strings to integer representing seconds, atomically and indempotently"
+  task convert_timer_to_seconds: :environment do
+    UserDaily.where(temp_timer_seconds = nil).find_each do |user_daily|
+      UserDaily.transaction do
+        begin
+          h, m, s = user_daily.timer.map(&:to_i)
+          total_seconds = h * 3600 + m * 60 + s
+          # update! will raise an exception if the update fails
+          user_daily.update!(temp_timer_seconds: total_seconds)
+        rescue => e
+          # log error & rollback transaction
+          Rails.logger.error "Failed to update UserDaily #{user_daily.id}. Error: #{e.message}"
+          Raise ActiveRecord::Rollback
+        end
+      end
+    end
+  end
+end
+
+namespace :user_micro do
+  desc "Convert timer from array of strings to integer representing seconds, atomically and indempotently"
+  task convert_timer_to_seconds: :environment do
+    UserMicro.where(temp_timer_seconds = nil).find_each do |user_micro|
+      UserMicro.transaction do
+        begin
+          h, m, s = user_micro.timer.map(&:to_i)
+          total_seconds = h * 3600 + m * 60 + s
+          # update! will raise an exception if the update fails
+          user_micro.update!(temp_timer_seconds: total_seconds)
+        rescue => e
+          # log error & rollback transaction
+          Rails.logger.error "Failed to update UserMicro #{user_micro.id}. Error: #{e.message}"
+          Raise ActiveRecord::Rollback
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/update_timer_format.rake
+++ b/lib/tasks/update_timer_format.rake
@@ -2,13 +2,15 @@
 
 # These rake tasks were used as part of changing the data type by which the wordcross timers were represented. Originally, the timer data was stored as an array of strings, `["00", "00", "00"]`. The strings were converted to 3 integers in Redux state, then changed back to strings when the value was updated in the database... not good, obviously. Unnecessary complexity and potential for error.
 
-# Migrations 20240221223856_add_temp_timer_to_user_dailies.rb and 20240221231948_add_temp_timer_to_user_micros.rb added a temporary column to the UserDailies and UserMicros tables for storing the timer as an integer representing elapsed seconds. These tasks convert the old string data to the new integer format and store them in the temporary columns. They only update records that have not yet been updated, and rollback the transaction if an error occurs, so they are indempotent and atomic.
+# Migrations 20240221223856_add_temp_timer_to_user_dailies.rb and 20240221231948_add_temp_timer_to_user_micros.rb added a temporary column to the UserDailies and UserMicros tables. These temporary columns were to store the timer as an integer representing elapsed seconds. These tasks convert the old string data to the new integer format and store them in the temporary columns. They only update records that have not yet been updated, and rollback the transaction if an error occurs, so they are indempotent and atomic.
 
-# As of 2/21/2024, these tasks were run once in development. I will run those migrations on production, and then run these rake tasks on production.
+# As of 2/21/2024, these tasks were run once in development. I will run those migrations on production as well to create the temporary columns.
 
-# A migration to remove the old timer columns and rename the temporary versions as :timer will be created and it will be run on production when the entire statistics feature is deployed. That deploy will include an updated seed file that will populate the timer columns with integers, not arrays of strings.
+# As part of the statistics feature, a migration to remove the old timer columns and rename the temporary versions as :timer will be created. That feature will include an updated seed file that will populate the timer columns with integers, not arrays of strings.
 
-# Following the deployment, this task should be irrelevant and may be deleted or kept for historical purposes.
+# When the statistics feature is ready for deployment, BEFORE DEPLOYING THE UPDATE, THESE TASKS SHOULD BE RUN ON PRODUCTION to convert existing timer records and store them in the temporary columns. WHEN THESE TASKS HAVE BEEN SUCCESSFULLY RUN, the renaming migrations will run as part of deploying the statistics feature.
+
+# Following the deployment, these tasks should be irrelevant and may be deleted, or kept for historical purposes.
 
 namespace :user_daily do
   desc "Convert timer from array of strings to integer representing seconds, atomically and indempotently"


### PR DESCRIPTION
Context: 
The data format of the `:timer` for both `UserDailies` and `UserMicros` is, well, stupid. Storing the timer as an array of strings for hours, minutes, and seconds, e.g. `["0", "4", "39"], then converting it to three integers whilst in Redux state, then back into strings when updated in the database? Unnecessary complexity, high potential for errors, and all kinds of naive.

Changes:
- Adds two migrations to add a column, `:temp_timer_seconds` to both the `UserDailiies` and `UserMicros` tables, which will be used to temporarily store integers representing the number of elapsed seconds of a Wordcross timer.
- Adds two rake tasks that will take existing timer records, extract them into an integer representing elapsed seconds, and store those integers in the temporary columns.
- NOTE: These rake tasks will not be run in prod at this time. Rather I will run them immediately before deploying the new Stats feature. That feature will contain migrations that will remove the old `:timer` column and rename the `:temp_timer_seconds` as `:timer`.